### PR TITLE
Don’t autostart PHP remote debugging.

### DIFF
--- a/templates/default/xdebug.ini.erb
+++ b/templates/default/xdebug.ini.erb
@@ -5,7 +5,7 @@ xdebug.cli_color = 1
 
 [xdebug-remote-debug]
 xdebug.remote_enable = On
-xdebug.remote_autostart = 1
+xdebug.remote_autostart = 0
 xdebug.remote_mode = req
 xdebug.remote_connect_back = 1
 xdebug.idekey = macgdbp


### PR DESCRIPTION
I’m sure I’m not the only one who added the xdebug recipe to my dev environment’s runlist only to wonder why every PHP page request started hanging for two minutes. It turns out this is because Xdebug was configured to automatically start remote debugging, and I did not have a debugger running on my host machine.

I suggest, therefore, that the default configuration established by this recipe should not autostart remote debugging. Instead, remote debugging should be triggered by a GET request variable (a URL query string), which is how IDEs like NetBeans are designed to work with Xdebug, and how commonly-used packages that include Xdebug like MAMP are configured out of the box.

Certainly, individual developers could modify the `xdebug.ini.erb` template to autostart remote debugging if that’s appropriate for their setup, but I think the out-of-the-box configuration should be one that’s “safe” (in that it won’t cause requests to hang if you don’t have a debugger waiting to receive the connection).
