### PR TITLE
Fix default value for xcache.cacher to be On by default

### DIFF
--- a/templates/default/xcache.ini.erb
+++ b/templates/default/xcache.ini.erb
@@ -11,7 +11,7 @@ xcache.test =       <%= @params['test'] %>
 ;xcache.coredump_directory = ""
 
 [xcache]
-xcache.cacher =               <%= @params['test'] %>
+xcache.cacher =               <%= @params['cacher'] %>
 xcache.size  =                <%= @params['size'] %>
 xcache.count =                <%= @params['count'] %>
 xcache.slots =                <%= @params['slots'] %>


### PR DESCRIPTION
Default value for the xcache.cacher option was being set by the wrong source. This change fixes that bug.
