### PR TITLE
do not pin explicit cookbook versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ description      "Installs/Configures additional PHP modules, PEAR and PECL pack
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.0"
 
-depends "git", "= 1.0.0"
-depends "yum", "= 0.8.0"
-depends "apt", "= 1.8.4"
-depends "php", "= 1.1.8"
+depends "git", ">= 1.0.0"
+depends "yum", ">= 0.8.0"
+depends "apt", ">= 1.8.4"
+depends "php", ">= 1.1.8"
 depends "chef-php-extra"
 
 %w{ ubuntu, debian, centos, redhat, fedora }.each do |os|


### PR DESCRIPTION
we run in an error when using librarian-chef with other cookbooks which requires newer cookbooks (e.g. git). I don't think this cookbook ultimately requires an explicit cookbook version.

``` bash
depends "git", "= 1.0.0"
```

leads to an hard to track error:

``` bash
persist_resolution_mixin.rb:11:in `persist_resolution': undefined method `correct?' for nil:NilClass (NoMethodError)
```

this (and the other dependencies) should be at least

``` bash
depends "git", ">= 1.0.0"
```
