### PR TITLE
Feature/correct explicit dependency references

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          "0.2.0"
 depends "git", ">= 1.0.0"
 depends "yum", ">= 0.8.0"
 depends "apt", ">= 1.8.4"
-depends "php", ">= 1.1.8"
+depends "php", "= 1.1.8"
 depends "chef-php-extra"
 
 %w{ ubuntu, debian, centos, redhat, fedora }.each do |os|


### PR DESCRIPTION
This pull request resolves the requests relaxation of non critical dependencies of the cookbook. However it maintains the explicit dependency to the version of Opscode PHP as this has caused some BC breaks in the past.

This new pull request is directed to the develop branch of the repos and includes the codes from #15 
