### PR TITLE
Allow attribute for PHPUnit version to be set via config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,3 +35,5 @@ default['xcache']['readonly_protection'] = 'Off'
 default['xcache']['mmap_path'] = '/dev/zero'
 default['xcache']['optimizer'] = 'Off'
 default['xcache']['coverager'] = 'Off'
+
+default['phpunit']['version'] = '3.6.11'

--- a/recipes/PHPUnit.rb
+++ b/recipes/PHPUnit.rb
@@ -20,7 +20,7 @@
 include_recipe "chef-php-extra::pear"
 
 channels = [
-    "pear.symfony-project.com", 
+    "pear.symfony-project.com",
     "components.ez.no"
 ]
 
@@ -35,7 +35,7 @@ pu = chef_php_extra_pear_channel "pear.phpunit.de" do
 end
 
 chef_php_extra_pear "PHPUnit" do
-    version "3.6.11"
+    version node['phpunit']['version']
     channel pu.channel_name
     action :install
 end


### PR DESCRIPTION
Have a problem sometimes running PHPUnit tests with out-of-date version of PHPUnit.

Patch allows the version of PHPUnit to be set in the config so a more up-to-date version can be installed.
