### PR TITLE
Fix error with being unable to install php codesniffer on ubuntu 12.10

### DIFF
--- a/recipes/PHP_CodeSniffer.rb
+++ b/recipes/PHP_CodeSniffer.rb
@@ -19,7 +19,7 @@
 
 include_recipe "chef-php-extra::pear"
 
-php_pear "PHP_CodeSniffer" do
+chef_php_extra_pear "PHP_CodeSniffer" do
   version "1.3.5"
   action :install
 end


### PR DESCRIPTION
Recipe for PHP Codesniffer was specifying php_pear instead of
the internal chef_php_extra_pear, which was resulting in the following
error:

[2013-05-10T16:10:59+00:00] ERROR: php_pear[PHP_CodeSniffer](chef-php-extra::PHP_CodeSniffer line 22) has had an error
[2013-05-10T16:10:59+00:00] ERROR: php_pear[PHP_CodeSniffer](/tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-php-extra/recipes/PHP_CodeSniffer.rb:22:in
`from_file') had an error:
php_pear[PHP_CodeSniffer](chef-php-extra::PHP_CodeSniffer line 22) had an
error: NameError: Cannot find a resource for converge_by on ubuntu version
12.10
