### PR TITLE
Fixed predis recipe dependency to work for all PHP versions/platforms.

### DIFF
--- a/recipes/predis.rb
+++ b/recipes/predis.rb
@@ -25,9 +25,7 @@ package "make" do
 end
 
 # phpize command
-package "php5-dev" do
-  action :install
-end
+include_recipe "chef-php-extra::module_dev"
 
 directory "/tmp/phpredis" do
   owner "root"


### PR DESCRIPTION
The dependency on 'php5-dev' was hard-coded into the predis recipe, but that doesn't work in all cases (I'm using PHP 5.3 IUS on CentOS 6.4 for example). The module_dev recipe already determines the right package for each platform, so it can use that instead.
