### PR TITLE
Add "xdebug -> remote_host" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following Opscode cookbooks are dependencies:
 * `['xdebug']['cli_color']` = Enable cli colour output, defaults to `1`.
 * `['xdebug']['scream']` = Enable removal for of `@` error suppression functionality, defaults to `0`.
 * `['xdebug']['remote_enable']` = Defaults to `On`.
+* `['xdebug']['remote_host']` = Defaults to `localhost`.
 * `['xdebug']['remote_autostart']` = Defaults to `0`.
 * `['xdebug']['remote_mode']` = Defaults to `req`.
 * `['xdebug']['remote_connect_back']` = Defaults to `1`.
@@ -151,7 +152,7 @@ Installs the php twig extension configure and make install from source after a c
 You can select any of the recipes to be executed directly referencing them from this cookbook.
 
     chef-php-extra::xdebug
-    
+
 If you are setting up a development environment you can use the single recipe that will add all the standard tools that may be used during development of projects
 
     chef-php-extra::development

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default['xdebug']['cli_color'] = 1
 default['xdebug']['scream'] = 0
 default['xdebug']['remote_enable'] = "On"
 default['xdebug']['remote_autostart'] = 0
+default['xdebug']['remote_host'] = 'localhost'
 default['xdebug']['remote_mode'] = "req"
 default['xdebug']['remote_connect_back'] = 1
 default['xdebug']['idekey'] = "macgdbp"

--- a/templates/default/xdebug.ini.erb
+++ b/templates/default/xdebug.ini.erb
@@ -5,6 +5,7 @@ xdebug.scream = <%= @params['scream'] %>
 
 [xdebug-remote-debug]
 xdebug.remote_enable = <%= @params['remote_enable'] %>
+xdebug.remote_host = <%= @params['remote_host'] %>
 xdebug.remote_autostart = <%= @params['remote_autostart'] %>
 xdebug.remote_mode = <%= @params['remote_mode'] %>
 xdebug.remote_connect_back = <%= @params['remote_connect_back'] %>


### PR DESCRIPTION
Hello,

I have added the support of "remote_host" configuration option for xdebug.
Should I do something except pull request to make it possible to merge this change into master?
