### PR TITLE
Update imagick package names

### DIFF
--- a/recipes/module_imagick.rb
+++ b/recipes/module_imagick.rb
@@ -18,13 +18,12 @@
 #
 
 include_recipe "chef-php-extra"
-
 if node['php']['ius'] == "5.4"
-  packages = %w{ php54-imagick }
+  packages = %w{ php54-pecl-imagick }
 elsif node['php']['ius'] == "5.3"
-  packages = %w{ php53u-imagick }
+  packages = %w{ php53u-pecl-imagick }
 else
-  packages = %w{ php-imagick }
+  packages = %w{ php-pecl-imagick }
 end
 
 pkgs = value_for_platform(


### PR DESCRIPTION
The package names for the imagick recipe were not working with CentOS 6.4
